### PR TITLE
fix: make sleep() async and await all call sites

### DIFF
--- a/src/lib/wallet.js
+++ b/src/lib/wallet.js
@@ -49,8 +49,8 @@ const sha256 = bitcore.crypto.Hash.sha256;
 function msleep(n) {
   return new Promise((resolve) => setTimeout(resolve, n));
 }
-function sleep(n) {
-  msleep(n * 1000);
+async function sleep(n) {
+  await msleep(n * 1000);
 }
 
 export class WalletFile extends events.EventEmitter {
@@ -1069,16 +1069,16 @@ export class WalletFile extends events.EventEmitter {
 
       if (this.failedConnections >= this.electrumNodes.length) {
         this.emit("no_servers_available");
-        sleep(5);
+        await sleep(5);
         await this.Connect(true);
       } else {
-        sleep(1);
+        await sleep(1);
         await this.Connect(false);
       }
     }
 
     if (e === "server busy - request timed out") {
-      sleep(5);
+      await sleep(5);
     }
   }
 
@@ -1829,7 +1829,7 @@ export class WalletFile extends events.EventEmitter {
       } catch (e) {
         this.Log(`error getting tx ${hash}: ${e}`);
         await this.ManageElectrumError(e);
-        sleep(1);
+        await sleep(1);
         return await this.GetTx(hash, inMine, height, requestInputs);
       }
 
@@ -2519,7 +2519,7 @@ export class WalletFile extends events.EventEmitter {
       } catch (e) {
         this.Log(`error getting tx keys ${hash}: ${e}`);
         await this.ManageElectrumError(e);
-        sleep(3);
+        await sleep(3);
         return await this.GetTxKeys(hash, height, useCache);
       }
       txKeys.txidkeys = hash;


### PR DESCRIPTION
## Problem

`sleep()` calls `msleep()` without `await`, so the intended delays in `ManageElectrumError` have no effect:

```js
// before
function sleep(n) {
  msleep(n * 1000); // Promise is created but not awaited — returns immediately
}
```

When multiple Electrum servers are unreachable, `ManageElectrumError` is supposed to wait 1–5 seconds between reconnect attempts. Because the delays are silently dropped, the reconnect loop spins at full CPU speed, cycling through all dead nodes instantly, flooding logs with errors, and preventing the wallet from settling on a working server.

## Fix

Make `sleep()` async and add `await` at all five call sites:

```js
// after
async function sleep(n) {
  await msleep(n * 1000);
}
```

Call sites updated:
- `ManageElectrumError`: `sleep(5)` before `Connect(true)` (all servers failed)
- `ManageElectrumError`: `sleep(1)` before `Connect(false)` (try next server)
- `ManageElectrumError`: `sleep(5)` when server is busy
- `GetTx`: `sleep(1)` after error before retry
- `GetTxKeys`: `sleep(3)` after error before retry

## Impact

With this fix, reconnect attempts properly wait before retrying, reducing CPU usage and log noise when Electrum servers are partially unavailable.