### PR TITLE
fix(wallet): honor custom electrum node lists

### DIFF
--- a/src/lib/wallet.js
+++ b/src/lib/wallet.js
@@ -247,8 +247,8 @@ export class WalletFile extends events.EventEmitter {
     this.type = (await this.db.GetValue("walletType")) || "navcoin-js-v1";
 
     this.electrumNodes =
-      options.nodes && option.nodes[this.network]
-        ? option.nodes[this.network]
+      options.nodes && options.nodes[this.network]
+        ? options.nodes[this.network]
         : nodes[this.network];
 
     if (!this.electrumNodes.length) {


### PR DESCRIPTION
## Summary
- fix the `option.nodes` typo in `WalletFile` initialisation
- allow callers that pass `options.nodes[network]` to override the default Electrum server list as intended

## Verification
- reviewed the affected source path and confirmed the typo blocks custom node-list injection
- attempted local build verification, but this clone's legacy native dependency toolchain fails under current Node 24 / node-gyp due to Python 2-era assumptions